### PR TITLE
Small fix of the banner description of Pokémon Pinball R&S

### DIFF
--- a/_nds/TWiLightMenu/icons/_meta.json
+++ b/_nds/TWiLightMenu/icons/_meta.json
@@ -552,7 +552,7 @@
 	"Pokémon Pinball - Ruby & Sapphire": {
 		"title": "Pokémon Pinball: Ruby & Sapphire",
 		"author": "SombrAbsol",
-		"description": "Custom banner for Pokémon Pinball on NDS.",
+		"description": "Custom banner for Pokémon Pinball on GBA.",
 		"categories": ["gba", "pokemon", "pokemon-pinball", "animated"]
 	},
 	"Pokémon Mystery Dungeon - Red Rescue Team": {


### PR DESCRIPTION
On my previous pull request, I accidentally said it was an NDS game, when it's GBA.