### PR TITLE
Add outdated skin warning in skin descriptions

### DIFF
--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/Ace Attorney/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/Ace Attorney/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Phoenix Wtight - Ace Attorney",
 	"author": "Allinxter",
-	"description": "Objection! Think you can bluff your way of this trial?",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Objection! Think you can bluff your way of this trial?",
 	"categories": ["ace", "attorney", "phoenix", "wright", "objection"],
 	"version": "v1.0.1"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/Chrono Trigger/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/Chrono Trigger/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Chrono Trigger",
 	"author": "Allinxter",
-	"description": "Do you think you can change the flow of time, and save the world?",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Do you think you can change the flow of time, and save the world?",
 	"categories": ["chrono", "trigger", "lucca", "robo", "marle", "ayla", "frog", "magus", "square"],
 	"version": "v1.0.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/HGSS/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/HGSS/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Pokémon HGSS - Tower Duo",
 	"author": "Allinxter",
-	"description": "Marvelous llustrations of Ho-oh and Lugia accompany the gold and silver colors that make this theme.",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Marvelous llustrations of Ho-oh and Lugia accompany the gold and silver colors that make this theme.",
 	"categories": ["pokemon", "illustrations", "ho-oh", "lugia", "gold", "silver"],
 	"version": "v2.0.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/KyuremBW2/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/KyuremBW2/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Pokémon BW2 - Kyurem",
 	"author": "Allinxter",
-	"description": "Monochromatic theme based on the fused forms of Kyurem",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Monochromatic theme based on the fused forms of Kyurem",
 	"categories": ["pokemon", "simple", "minimalist", "monochrome", "kyurem", "ghetsis"],
 	"version": "v2.0.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/P3 Blue/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/P3 Blue/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Persona 3 - S.E.E.S. (Blue)",
 	"author": "Allinxter",
-	"description": "Warning: Even with this skin on, your console won't work during the Dark Hour.",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Warning: Even with this skin on, your console won't work during the Dark Hour.",
 	"categories": ["persona", "sees", "tartarus", "minato", "arisato", "yuki", "makoto"],
 	"version": "v1.2.1"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/P3 Gold/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/P3 Gold/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Persona 3 - S.E.E.S. (Gold)",
 	"author": "Allinxter",
-	"description": "March 31st, 2010",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. March 31st, 2010",
 	"categories": ["persona", "sees", "tartarus", "aigis", "toaster", "gold", "yellow"],
 	"version": "v1.31.5.1"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/P3 Pink/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/P3 Pink/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Persona 3 - S.E.E.S. (Pink)",
 	"author": "Allinxter",
-	"description": "Warning: Even with this skin on, your console won't work during the Dark Hour.",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Warning: Even with this skin on, your console won't work during the Dark Hour.",
 	"categories": ["persona", "sees", "tartarus", "minako", "arisato", "kotone", "shiomi"],
 	"version": "v1.2.1"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/Persona 4/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/Persona 4/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Persona 4 - Investigation Team",
 	"author": "Allinxter",
-	"description": "Put on your glasses, get on your headphones and practice your best bear puns. It's time to get inside the TV again!",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Put on your glasses, get on your headphones and practice your best bear puns. It's time to get inside the TV again!",
 	"categories": ["persona", "investigation-team", "tv", "midnight-channel", "yu", "teddie"],
 	"version": "v1.2.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/Phantom Thieves/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/Phantom Thieves/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Persona 5 - The Phantom Thieves",
 	"author": "Allinxter",
-	"description": "You never saw this skin coming!",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. You never saw this skin coming!",
 	"categories": ["persona", "joker", "phantom", "thieves", "phantom-thieves"],
 	"version": "v1.2.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/Spider-Man/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/Spider-Man/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Spider-Man",
 	"author": "Allinxter",
-	"description": "With great power there must also come great responsibility. And with a great theme, also comes a great tune!",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. With great power there must also come great responsibility. And with a great theme, also comes a great tune!",
 	"categories": ["spider-man", "marvel", "spider", "red", "blue", "web"],
 	"version": "v1.2.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/TBOI/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/TBOI/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "The Binding of Isaac",
 	"author": "Allinxter",
-	"description": "Skin contains images with cartoony grotesque physique and blood. Follow Isaac into the basement to face deranged enemies, find lost brothers and sisters, face his fears, and play Mario Kart, Pokémon and Tetris on his old DS.",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Skin contains images with cartoony grotesque physique and blood. Follow Isaac into the basement to face deranged enemies, find lost brothers and sisters, face his fears, and play Mario Kart, Pokémon and Tetris on his old DS.",
 	"categories": ["tboi", "rebirth", "isaac", "binding of isaac", "nicalis", "repentance", "afterbirth"],
 	"version": "v1.1.1"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/TLoZ/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/TLoZ/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "The Legend of Zelda",
 	"author": "Allinxter",
-	"description": "Blue, green and golden colors, a landscape of Hyrule and a familiar tune welcome you to TWiLight Menu++",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Blue, green and golden colors, a landscape of Hyrule and a familiar tune welcome you to TWiLight Menu++",
 	"categories": ["legend-of-zelda", "zelda", "botw", "link", "green"],
 	"version": "v1.2.1"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/Terraria/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/Terraria/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Terraria",
 	"author": "Allinxter",
-	"description": "Don't worry, no boulders to watch out for in here!",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Don't worry, no boulders to watch out for in here!",
 	"categories": ["terraria", "relogic", "guide", "green", "journey", "cthulhu", "slime"],
 	"version": "v1.2.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/Windows 7/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/Windows 7/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Windows 7 Aero - Harmony",
 	"author": "Allinxter",
-	"description": "Enjoy the elegance of Aero, now on your favorite portable console.",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Enjoy the elegance of Aero, now on your favorite portable console.",
 	"categories": ["windows", "7", "computer", "harmony", "aero"],
 	"version": "v1.0.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/XP Luna Blue/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/XP Luna Blue/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "Windows XP - Luna Blue",
 	"author": "Allinxter",
-	"description": "Welcome back to 2005! This is a rendition of Windows XP's default theme. ",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Welcome back to 2005! This is a rendition of Windows XP's default theme. ",
 	"categories": ["windows", "xp", "computer", "luna", "blue"],
 	"version": "v1.2.0"
 }

--- a/_nds/TWiLightMenu/3dsmenu/themes/meta/iDS/info.json
+++ b/_nds/TWiLightMenu/3dsmenu/themes/meta/iDS/info.json
@@ -1,7 +1,7 @@
 {
 	"title": "iDS",
 	"author": "Allinxter",
-	"description": "Think Distinct.",
+	"description": "This skin was made for an old version of TWiLight Menu++ and hasn't been updated yet. Some graphics will not be displayed. Think Distinct.",
 	"categories": ["iOS", "iDS", "apple", "phone", "mac", "dynamic-island"],
 	"version": "v2.16.4"
 }


### PR DESCRIPTION
Recent update has added some new icons to the 3DS theme. I don't have the time to update the existing skins and reconfigure macro mode, so I thought about at least adding a warning to let users know this may be an issue.

Will update the skins and remove this added text as soon as I have the time, but I have no clue when this will be.