### PR TITLE
Remove mention of sending skins in the Discord server

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ To see all available skins for the theme you're using, click the theme in the to
 To make your own skins, there's a [wiki page on how to make Nintendo DSi / Nintendo 3DS skins](https://wiki.ds-homebrew.com/twilightmenu/custom-dsi-3ds-skins). For Original R4 and Wood UI skins simply edit the images from an existing skin.
 {:.i18n .innerHTML-home-3}
 
-If you want your skin added here, make a pull request on the GitHub repository or send it and ask on the [DS⁽ⁱ⁾ Mode Hacking Discord server](https://discord.gg/fCzqcWteC4).
+If you want your skin added here, [create a pull request](https://github.com/DS-Homebrew/twlmenu-extras/pulls) on the GitHub repository.
 {:.i18n .innerHTML-home-4}
 
 If you're on a 2DS or 3DS, all of the skins on this site can be downloaded directly on console using Universal-Updater. To add the UniStore go to settings, choose `Select UniStore`, tap the + button at the bottom, and select `TWiLight Menu++ Skins` to add. Once it's added simply select `twlmenu-skins.unistore` from the Select UniStore menu to switch to it.


### PR DESCRIPTION
Removes mention of sending skins in the Discord server for someone else to pull request it for them.

Reason: I've only seen this happen a few times. Most often, the skins or icons will be uploaded there and be forgotten. Someone either needs to pick up on this and create better systemization of the process, or discard it as I'm proposing.

If we want to have an "easy" method of uploading skins, it would be better to have a form that will generate a pull request using inputted files and text.