### PR TITLE
Fix site building on newer ruby versions

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -30,3 +30,8 @@ end
 gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
 
 gem "webrick", "~> 1.9.1"
+
+gem "csv", "~> 3.3.3"
+gem "base64", "~> 0.2.0"
+gem "bigdecimal", "~> 3.1.9"
+gem "logger", "~> 1.6.0"


### PR DESCRIPTION
csv, base64 and bigdecimal are no longer part of Ruby 3's standard library, they are now available as separate gems. 

This change happened with Ruby 3.4.0, as such, the site cannot build on newer Ruby versions without specifying these gems in the Gemfile. 

Logger will be removed in 3.5.0, the last working version for Jekyll 4.2 seems to be 1.6.6 so I've also added that to the Gemfile.